### PR TITLE
Add options to generate additional case attributes during run time

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -15,7 +15,9 @@ const config = {
   SHOW_PROGRESS: true,
   PROGRESS_INTERVAL: 1100,
   FILE_NAME_PREFIX: "Cases",
-  INCLUDE_RECORD_COUNT_IN_FILE_NAME: true
+  INCLUDE_RECORD_COUNT_IN_FILE_NAME: true,
+  DYNAMIC_ATTRS: 0,
+  UNIQUE_VALUES_FOR_DYNAMIC_ATTRS: 10
 };
 
 function loadAndSetUserConfigurations() {
@@ -62,14 +64,18 @@ function loadAndSetUserConfigurations() {
       config.FILE_NAME_PREFIX = nextArg;
     } else if (arg === "-verbosename" && i + 1 < args.length) {
       config.INCLUDE_RECORD_COUNT_IN_FILE_NAME = (nextArg.toLowerCase() == "true")
-    } 
+    } else if (arg === "-dynamicattrs" && i + 1 < args.length) {
+      config.DYNAMIC_ATTRS = parseFloat(nextArg);
+    } else if (arg === "-uniquevalues" && i + 1 < args.length) {
+           config.UNIQUE_VALUES_FOR_DYNAMIC_ATTRS = parseFloat(nextArg);
+    }
   }
 }
 
 function printHelp() {
   console.log("\nUsage:");
   console.log(
-    "node app.js -cases [value] -timeframe [value] -format [value] -sqlbatchsize [value] -minevents [value] -maxevents [value] -mindays [value] -maxdays [value] -minhours [value] -maxhours [value] -minminutes [value] -maxminutes [value] -progress [value] -progressinterval [value]\n"
+    "node app.js -cases [value] -timeframe [value] -format [value] -sqlbatchsize [value] -minevents [value] -maxevents [value] -mindays [value] -maxdays [value] -minhours [value] -maxhours [value] -minminutes [value] -maxminutes [value] -progress [value] -progressinterval [value] -dynamicattrs [value] -uniquevalues [value]\n"
   );
   console.log(
     `-cases: The number of cases to generate. (Default: ${config.NUMBER_OF_CASES})`
@@ -116,9 +122,14 @@ function printHelp() {
   console.log(
     `-prefix: The prefix for the name of the generated files. (Default: ${config.FILE_NAME_PREFIX})`
   );
-
   console.log(
     `-verbosename: Whether to include the record count in the "-all" file name. (Default: ${config.INCLUDE_RECORD_COUNT_IN_FILE_NAME})`
+  );
+  console.log(
+    `-dynamicattrs: Number of dynamically generated case attributes. (Default: ${config.DYNAMIC_ATTRS})`
+  );
+  console.log(
+    `-uniquevalues: Number of unique values for each dynamically generated case attribute. (Default: ${config.UNIQUE_VALUES_FOR_DYNAMIC_ATTRS})`
   );
   console.log("\n");
 }

--- a/src/data.js
+++ b/src/data.js
@@ -123,17 +123,4 @@ function valueToForeignKey(value, table) {
   return vocabulary.data[table][value];
 }
 
-function generateDynamicCaseAttrs(numOfAttrs, numOfUniqueValues){
-  const dynamicDict = {};
-  const str = "Dynamic_";
-  for (let i=1; i<=numOfAttrs; i++) {
-    const uniqueWords = new Set();
-    while (uniqueWords.size < numOfUniqueValues) {
-      uniqueWords.add(faker.word.sample({ length: { min: 8, max: 15 }, strategy: "closest" }));
-    }
-    dynamicDict[`${str}${i}`] = Array.from(uniqueWords);
-  }
-  return dynamicDict;
-}
-
-module.exports = { generateCases, generateEvents, generateDynamicCaseAttrs };
+module.exports = { generateCases, generateEvents };

--- a/src/data.js
+++ b/src/data.js
@@ -123,4 +123,17 @@ function valueToForeignKey(value, table) {
   return vocabulary.data[table][value];
 }
 
-module.exports = { generateCases, generateEvents };
+function generateDynamicCaseAttrs(numOfAttrs, numOfUniqueValues){
+  const dynamicDict = {};
+  const str = "Dynamic_";
+  for (let i=1; i<=numOfAttrs; i++) {
+    const uniqueWords = new Set();
+    while (uniqueWords.size < numOfUniqueValues) {
+      uniqueWords.add(faker.word.sample({ length: { min: 8, max: 15 }, strategy: "closest" }));
+    }
+    dynamicDict[`${str}${i}`] = Array.from(uniqueWords);
+  }
+  return dynamicDict;
+}
+
+module.exports = { generateCases, generateEvents, generateDynamicCaseAttrs };

--- a/src/mocker.js
+++ b/src/mocker.js
@@ -1,6 +1,6 @@
 const { loadAndSetUserConfigurations, config } = require('./config');
 const { processVocabulary } = require('./vocabulary');
-const { generateCases, generateEvents, generateDynamicCaseAttrs } = require('./data');
+const { generateCases, generateEvents } = require('./data');
 const { saveToCSV, writeFile } = require('./output');
 const { generateSchemaSql, generateSqlInsert } = require('./sql_generator');
 const util = require('./util');
@@ -8,9 +8,7 @@ const pluralize = require('pluralize');
 
 async function main() {
   loadAndSetUserConfigurations();
-
-  const dynamicCaseAttrs = generateDynamicCaseAttrs(config.DYNAMIC_ATTRS, config.UNIQUE_VALUES_FOR_DYNAMIC_ATTRS);
-  const vocabulary = processVocabulary(dynamicCaseAttrs);
+  const vocabulary = processVocabulary();
 
   const cases = generateCases(config.NUMBER_OF_CASES);
   const events = generateEvents(cases);
@@ -36,7 +34,6 @@ async function main() {
 
 function saveToSql(vocabulary, cases, events) {
   let combinedFile = '';
-  let additionalCaseAttrs = 10
 
   const schema = generateSchemaSql(vocabulary.schema);
   writeFile('out/schema.sql', schema);

--- a/src/vocabulary.js
+++ b/src/vocabulary.js
@@ -8,8 +8,35 @@ const _vocabulary = {
   events: null
 };
 
-function processVocabulary() {
+function processVocabulary(dynamicCaseAttrs) {
   const items = parseVocabulary();
+
+  // Inject dynamic attributes to the vocabulary json
+  Object.entries(dynamicCaseAttrs).forEach(([key, value]) => {
+    // Add new column to the schema
+    const newColumn = {
+               name: key.toLowerCase(),
+               display_name: key.replace(/_/g,""),
+               type: "varchar(50)",
+               nullable: true
+             };
+    items["__schema__"]["cases"]["columns"].push(newColumn);
+
+    // Calculate weight for each value
+    let weight = 1;
+    if (value.length > 0) {
+      weight = 1/value.length;
+    }
+
+    // Create a dict with values as keys as weights as values
+    const valuesWithWeight = {}
+    for (let i = 0; i < value.length; i++) {
+        valuesWithWeight[value[i]] = weight;
+    }
+
+    // Add the dynamic attribute and weighted values to vocabulary json object
+    items[key] = valuesWithWeight
+  })
 
   for (const key in items) {
     if (key === "__schema__") {

--- a/src/vocabulary.js
+++ b/src/vocabulary.js
@@ -1,4 +1,6 @@
 const fs = require("fs");
+const { config } = require('./config');
+const { faker } = require("@faker-js/faker");
 
 const _vocabulary = {
   schema: {},
@@ -8,35 +10,12 @@ const _vocabulary = {
   events: null
 };
 
-function processVocabulary(dynamicCaseAttrs) {
+function processVocabulary() {
   const items = parseVocabulary();
 
-  // Inject dynamic attributes to the vocabulary json
-  Object.entries(dynamicCaseAttrs).forEach(([key, value]) => {
-    // Add new column to the schema
-    const newColumn = {
-               name: key.toLowerCase(),
-               display_name: key.replace(/_/g,""),
-               type: "varchar(50)",
-               nullable: true
-             };
-    items["__schema__"]["cases"]["columns"].push(newColumn);
-
-    // Calculate weight for each value
-    let weight = 1;
-    if (value.length > 0) {
-      weight = 1/value.length;
-    }
-
-    // Create a dict with values as keys as weights as values
-    const valuesWithWeight = {}
-    for (let i = 0; i < value.length; i++) {
-        valuesWithWeight[value[i]] = weight;
-    }
-
-    // Add the dynamic attribute and weighted values to vocabulary json object
-    items[key] = valuesWithWeight
-  })
+  if(config.DYNAMIC_ATTRS > 0) {
+     includeDynamicAttributes(items);
+  }
 
   for (const key in items) {
     if (key === "__schema__") {
@@ -140,6 +119,49 @@ function parseVocabulary() {
 
 function getVocabulary() {
   return _vocabulary;
+}
+
+function generateDynamicCaseAttrs(numOfAttrs, numOfUniqueValues){
+  const dynamicDict = {};
+  const str = "Dynamic_";
+  for (let i = 1; i <= numOfAttrs; i++) {
+    const uniqueWords = new Set();
+    while (uniqueWords.size < numOfUniqueValues) {
+      uniqueWords.add(faker.word.sample({ length: { min: 8, max: 15 }, strategy: "closest" }));
+    }
+    dynamicDict[`${str}${i}`] = Array.from(uniqueWords);
+  }
+  return dynamicDict;
+}
+
+function includeDynamicAttributes(items) {
+  const dynamicCaseAttrs = generateDynamicCaseAttrs(config.DYNAMIC_ATTRS, config.UNIQUE_VALUES_FOR_DYNAMIC_ATTRS);
+
+  Object.entries(dynamicCaseAttrs).forEach(([key, value]) => {
+    // Add new columns into the schema
+    const newColumn = {
+      name: key.toLowerCase(),
+      display_name: key.replace(/_/g,""),
+      type: "varchar(50)",
+      nullable: true
+    };
+    items["__schema__"]["cases"]["columns"].push(newColumn);
+
+    // Calculate weight for each value
+    let weight = 1;
+    if (value.length > 0) {
+      weight = 1 / value.length;
+    }
+
+    // Create a dict with attr values as keys and weights as values
+    const valuesWithWeight = {}
+    for (let i = 0; i < value.length; i++) {
+      valuesWithWeight[value[i]] = weight;
+    }
+
+    // Add the dynamic attribute and weighted values to vocabulary json object
+    items[key] = valuesWithWeight
+  })
 }
 
 module.exports = { processVocabulary, getRandomString, getVocabulary };


### PR DESCRIPTION
The Process Mining Core team is trying to test the limits of the existing PM infrastructure. One of the dimensions they would like to explore is the increased complexity of data due to the large number of unique attribute values.

Currently, the mocker depends on a predefined set of strings defined in the vocabulary JSON for attribute names and their corresponding values. This PR aims to provide more flexibility for users who may want to generate additional attributes and values during runtime, which are not defined in the vocabulary JSON.

Following command line arguments are introduced:
`-dynamicattrs` - Number of dynamically generated case attributes. Default value is 0.
`-uniquevalues` - Number of unique values for each dynamically generated case attribute. Default is 10, used only if `-dynamicattrs > 0`.

Users should not notice any difference in the script's functionality if these additional arguments are ignored. PM core QEs are primarily interested in using this feature to generate CSV files. Therefore, no changes are necessary in the `miningStarterApp.sh` script, as it defaults to SQL format.

If we need to pass these new arguments from `miningStarterApp.sh` in the future, an update to the script will be necessary. A follow-up PR will be created for that purpose. Please note that in that case, the Jira record type design object will not be modified dynamically. Therefore, a manual step will be required to map these additional columns if they need to be used in Process HQ.

