### PR TITLE
Stream data to output files

### DIFF
--- a/src/mocker.js
+++ b/src/mocker.js
@@ -18,8 +18,8 @@ async function main() {
   }
 
   if (config.OUTPUT_FORMAT === 'csv') {
-    saveToCSV(`out/${fileNameForCases()}.csv`, cases);
-    saveToCSV(`out/${fileNameForEvents(events.length)}.csv`, events);
+    await saveToCSV(`out/${fileNameForCases()}.csv`, cases);
+    await saveToCSV(`out/${fileNameForEvents(events.length)}.csv`, events);
   } else if (config.OUTPUT_FORMAT === 'sql') {
     saveToSql(vocabulary, cases, events);
   } else {
@@ -32,12 +32,12 @@ async function main() {
   }
 }
 
-function saveToSql(vocabulary, cases, events) {
+async function saveToSql(vocabulary, cases, events) {
   deleteFile(`out/${fileNameForCombined()}.sql`);
   let combinedFile = '';
 
   const schema = generateSchemaSql(vocabulary.schema);
-  writeFile('out/schema.sql', schema);
+  await writeFile('out/schema.sql', schema);
   appendToCombinedSqlFile(schema + '\n\n');
 
   //"Lookup data"
@@ -52,22 +52,24 @@ function saveToSql(vocabulary, cases, events) {
       }
 
       const sqlInsertsData = generateSqlInsert(data, vocabulary.schema.data.find(e => e.lookup_for == table));
-      writeFile(`out/${fileNameForData(table)}.sql`, sqlInsertsData);
+      await writeFile(`out/${fileNameForData(table)}.sql`, sqlInsertsData);
       appendToCombinedSqlFile(sqlInsertsData + '\n\n');
     }
   }
 
   const sqlInsertsCases = generateSqlInsert(cases, vocabulary.schema.cases);
-  writeFile(`out/${fileNameForCases()}.sql`, sqlInsertsCases);
-  appendToCombinedSqlFile(sqlInsertsCases + '\n\n');
+  await writeFile(`out/${fileNameForCases()}.sql`, sqlInsertsCases);
+  appendToCombinedSqlFile(sqlInsertsCases);
+  appendToCombinedSqlFile('\n');
 
   const sqlInsertsEvents = generateSqlInsert(events, vocabulary.schema.events);
-  writeFile(`out/${fileNameForEvents(events.length)}.sql`, sqlInsertsEvents);
-  appendToCombinedSqlFile(sqlInsertsEvents + '\n\n');
+  await writeFile(`out/${fileNameForEvents(events.length)}.sql`, sqlInsertsEvents);
+  appendToCombinedSqlFile(sqlInsertsEvents);
+  appendToCombinedSqlFile('\n');
 }
 
-function appendToCombinedSqlFile(data) {
-  writeFile(`out/${fileNameForCombined()}.sql`, data, { flag: 'a'});
+async function appendToCombinedSqlFile(data) {
+  await writeFile(`out/${fileNameForCombined()}.sql`, data, { flags: 'a'});
 }
 
 function fileNameForCombined() {

--- a/src/output.js
+++ b/src/output.js
@@ -1,38 +1,97 @@
 const fs = require("fs");
 const path = require("path");
 const { config } = require("./config");
+const batchSize = 10000;
 
 function saveToCSV(filename, data) {
-  const headers = Object.keys(data[0]);
-  const filteredHeaders = headers.filter((header) => !header.startsWith("_"));
-  const headerRow = filteredHeaders.join(",") + "\n";
-  const dataRows = data
-    .map((row) => filteredHeaders.map((header) => row[header]).join(","))
-    .join("\n");
-  const csv = headerRow + dataRows;
-  writeFile(filename, csv);
+  return new Promise((resolve, reject) => {
+    if (!data || data.length === 0) {
+      console.error(`No data provided to write to ${filename}`);
+      return reject(new Error("Data is empty."));
+    }
+
+    const headers = Object.keys(data[0]);
+    const filteredHeaders = headers.filter((header) => !header.startsWith("_"));
+
+    const stream = fs.createWriteStream(filename);
+
+    stream.on('error', (err) => {
+      console.error(`Error writing to CSV file ${filename}: ${err.message}`);
+      reject(err);
+    });
+
+    stream.write(filteredHeaders.join(",") + "\n");
+
+    // Write data rows incrementally in batches
+    let batch = [];
+
+    data.forEach((row, index) => {
+      const rowData = filteredHeaders.map((header) => row[header] || "").join(",");
+      batch.push(rowData)
+
+      if (batch.length === batchSize || index === data.length - 1) {
+        stream.write(batch.join("\n") + "\n");
+        batch = [];
+      }
+    });
+
+    stream.end(() => {
+      resolve();
+    });
+  });
 }
 
 function writeFile(filename, data, opt) {
-  const dir = path.dirname(filename);
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
-  fs.writeFileSync(filename, data, opt);
+  return new Promise((resolve, reject) => {
+    const dir = path.dirname(filename);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    const stream = fs.createWriteStream(filename, opt);
+
+    stream.on('error', (err) => {
+      console.error(`Error writing to file ${filename}: ${err.message}`);
+      reject(err);
+    });
+
+    if (Array.isArray(data)) {
+      // Write data rows incrementally in batches
+      let batch = [];
+
+      data.forEach((row, index) => {
+        batch.push(row + '\n');
+
+        if (batch.length === batchSize || index === data.length - 1) {
+          stream.write(batch.join(''));
+          batch = [];
+        }
+      });
+    } else {
+      stream.write(data);
+    }
+
+    stream.end(() => {
+      resolve();
+    });
+  });
 }
 
 function deleteFile(filename) {
-  fs.access(filename, fs.constants.F_OK, (err) => {
-    if (err) {
-        return; //File doesn't exist. Ignore silently
-    }
+  try {
+    // Check if file exists
+    fs.accessSync(filename, fs.constants.F_OK);
 
-    fs.unlink(filename, (err) => {
-        if (err) {
-            console.error(`Error deleting file: ${err}`);
-        }
-    });
-});
+    // If file exists, proceed with unlinking it
+    fs.unlinkSync(filename);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      // File doesn't exist, ignore silently
+      return;
+    } else {
+      console.error(`Error deleting file: ${err}`);
+    }
+  }
 }
 
 module.exports = { saveToCSV, writeFile, deleteFile };

--- a/src/sql_generator.js
+++ b/src/sql_generator.js
@@ -29,7 +29,7 @@ function generateSqlInsert(data, schema) {
     statements.push(sql);
   }
 
-  return statements.join("\n");
+  return statements;
 }
 
 function generateDropTableSql(table) {


### PR DESCRIPTION
This PR aims to address the out-of-memory issue when generating large datasets (>10 million events). Currently, we load the entire case and event data into memory to manipulate them as strings, which requires more memory than is allocated for strings. The best approach for handling large data is to write it to a file by streaming one line at a time while performing the necessary manipulations. Following is a sample error output with current implementation:

```
$ node src/mocker.js -cases 2239000 -format sql
Generating cases... Completed
Generating events... Completed
Writing data to file...RangeError: Invalid string length
    at Array.join (<anonymous>)
    at generateSqlInsert (/Users/arjun.radhakrishnan/repo/mocker/src/sql_generator.js:32:21)
    at saveToSql (/Users/arjun.radhakrishnan/repo/mocker/src/mocker.js:60:27)
    at main (/Users/arjun.radhakrishnan/repo/mocker/src/mocker.js:24:5)
    at Object.<anonymous> (/Users/arjun.radhakrishnan/repo/mocker/src/mocker.js:94:1)
    at Module._compile (node:internal/modules/cjs/loader:1198:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1252:10)
    at Module.load (node:internal/modules/cjs/loader:1076:32)
    at Function.Module._load (node:internal/modules/cjs/loader:911:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
```

`fs.createWriteStream`, used for streaming, is asynchronous by nature compared to `fs.writeFileSync`. As a result, this PR also includes the necessary changes to ensure each write operation is a blocking call. Without this, the order in which data is written to the file is not guaranteed, especially when appending to an existing file.

Additionally, there was an existing issue with `fs.unlink` where its asynchronous nature resulted in the file being deleted after new data had been written to it. By replacing it with `fs.unlinkSync`, this issue no longer occurs.