### PR TITLE
AN-305094: Add guaranteed option for recent data

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -52,7 +52,7 @@ function generateEvents(cases) {
     caseNumber++;
 
     const vocabulary = getVocabulary();
-    const startDate = faker.date.past({ years: config.TIMEFRAME_IN_YEARS });
+    const startDate = getStartDate(caseNumber, numCases);
     let currentDate = moment(startDate);
 
     const variant = generateEventVariant()
@@ -200,6 +200,14 @@ function generateEventVariant() {
     // If maximum variants are reached, return a randomly selected pre-generated variant
     const randomIndex = Math.floor(Math.random() * variantsCount);
     return variantsMap[randomIndex];
+  }
+}
+
+function getStartDate(currentCase, totalCases) {
+  if (currentCase <= (config.RECENT_EVENT_FREQUENCY / 100) * totalCases) {
+    return faker.date.recent();
+  } else {
+    return faker.date.past({ years: config.TIMEFRAME_IN_YEARS });
   }
 }
 


### PR DESCRIPTION
These changes
1. Organize the config definition
2. Add an option for specifying a % of cases to occur starting in the last day.

This will be useful when guaranteeing data is available for testing email alerts.

![Screenshot 2025-02-27 at 4 29 19 PM](https://github.com/user-attachments/assets/d6a49fad-6ccf-4337-92b9-097d89796e49)
![Screenshot 2025-02-27 at 4 29 39 PM](https://github.com/user-attachments/assets/b60d3225-cdd0-4f87-9c12-a34fdacd4104)

https://appian-eng.atlassian.net/browse/AN-305094
